### PR TITLE
Update usage on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ yarn upgrade:
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "dep_upgrade"
+group :development do
+  gem "dep_upgrade"
+end
 ```
 
 And then execute:
@@ -49,6 +51,11 @@ Run:
 $ rails dep:upgrade
 ```
 
+For Rails 4.x and earlier,
+
+```
+$ bundle exec rake dep:upgrade
+```
 
 
 ## Development


### PR DESCRIPTION
Fix: https://github.com/blacktangent/dep_upgrade/issues/6

Changes:
- Add usage instruction for Rails 4.x and earlier
- Suggest to place the gem under :development group in Gemfile