### PR TITLE
Remove --all switch from bundle update for now

### DIFF
--- a/lib/dep_upgrade/command.rb
+++ b/lib/dep_upgrade/command.rb
@@ -64,7 +64,7 @@ module DepUpgrade
       return unless has_gemfile?
 
       puts "\n== Update all gems =="
-      system!("bundle update --all")
+      system!("bundle update")
     end
 
     def bundle_audit_update


### PR DESCRIPTION
Fix: https://github.com/blacktangent/dep_upgrade/issues/6

Since --all switch will be required on Bundler 2.0 only. We can
reintroduce it when Bundler 2.0 is released.

By removing the switch, the command will now work for all bundler
versions